### PR TITLE
Add Trident fuzzing framework to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - [Bloxy](https://bloxy.info/)
 - [Tenderly](https://dashboard.tenderly.co/)
 - [Tutela](https://tutela.xyz/)
+- [Trident](https://github.com/Ackee-Blockchain/trident)
 
 ## Audit reports
 


### PR DESCRIPTION
This PR adds Trident, the first fuzzing framework for Solana smart contracts.

As Solana grows in DeFi adoption, adding Solana-specific security tools would benefit the community.

Repository: https://github.com/Ackee-Blockchain/trident